### PR TITLE
Clean 'edit_form_after_editor' action addition

### DIFF
--- a/includes/class-ukuupeople.php
+++ b/includes/class-ukuupeople.php
@@ -1299,10 +1299,7 @@ LEFT JOIN {$wpdb->postmeta} pm1 ON pm1.post_id = SUBSTRING( pm1.meta_value, 15, 
     unset( $wp_meta_boxes['wp-type-contacts']['normal']['default']['wpcf-post-relationship'] );
     unset( $wp_meta_boxes['wp-type-contacts']['normal']['core']['slugdiv'] );
 
-    $screens = array( 'wp-type-activity' );
-    foreach ( $screens as $screen ) {
-      add_action( 'edit_form_after_editor', array( $this , 'ukuu_custom_touchpoint_list' ) );
-    }
+    add_action( 'edit_form_after_editor', array( $this , 'ukuu_custom_touchpoint_list' ) );
   }
 
   /**


### PR DESCRIPTION
Loop over a statically defined single entry array where the iterated item is not referenced?  Seems odd...